### PR TITLE
added support for caps_lock when it's being remapped as a modifier key

### DIFF
--- a/dvorak.c
+++ b/dvorak.c
@@ -97,6 +97,8 @@ static int modifier_bit(int key) {
             return 4;
         case KEY_LEFTMETA:
             return 8;
+        case KEY_CAPSLOCK:
+            return 16;
     }
     return 0;
 }


### PR DESCRIPTION
this is to fix #21 

after adding this to modifier_bit, i tested by activating gnome-tweaks > capslock as ctrl. dvorak was able to successfully turn to qwerty when i press capslock-* keys. (i.e. capslock-c emits ctrl-c not ctrl-j)

the only side effect is that when gnome-tweaks for capslock is not enabled (i.e. capslock is on its original function), pressing and holding capslock switches layout to qwerty. I feel this is a minor side effect.

i'm not familiar with umlaut layout but i don't think this change should change any of the existing behaviors.

i don't think this warrants an additional parameter, because as mentioned above the side effect is minor.

please let me know what you think. thanks!
