### PR TITLE
Add missing flag for getopt

### DIFF
--- a/dvorak.c
+++ b/dvorak.c
@@ -231,7 +231,7 @@ int main(int argc, char *argv[]) {
     char keyboard_name[UINPUT_MAX_NAME_SIZE] = "Unknown";
 
     char *device = NULL, *match = NULL;
-    while ((opt = getopt(argc, argv, "ud:m:t")) != -1) {
+    while ((opt = getopt(argc, argv, "ud:m:tc")) != -1) {
         switch (opt) {
             case 'u':
                 isUmlaut = true;


### PR DESCRIPTION
Sorry, I didn't get around to testing this until now because I had patched my own version to disable this option. This seems to fix the option.